### PR TITLE
Add missing translation keys for the Capes options Screen

### DIFF
--- a/src/main/resources/assets/osmium/lang/en_us.json
+++ b/src/main/resources/assets/osmium/lang/en_us.json
@@ -71,7 +71,12 @@
   "osmium.options.rgb_disabled": "Rgb: Disabled",
   "osmium.options.reset_color": "Reset Color",
   "osmium.options.transparency": "Transparency: ",
+  "osmium.options.animate_capes_enabled": "Disable animated Capes",
+  "osmium.options.animate_capes_disabled": "Enable animated Capes",
+  "osmium.options.show_other_capes_enabled": "Disable Other Capes",
+  "osmium.options.show_other_capes_disabled": "Enable Other Capes",
   "osmium.cape_select": "Select Cape",
+  "osmium.cape_options": "Cape Options",
   "osmium_failed_cape_load": "Failed to load custom cape pack",
   "osmium_failed_cape_load_title": "Error loading capes",
   "osmium.refresh": "Refresh"


### PR DESCRIPTION
### First:
What the titel says.

### Second:
The Capes Options Screen is maybe still being rendered a bit toooo big (about 30px in the height?, the width should be good then, this might also only apply to my 4:3 screens, sadly I don't have any other ones to test it with.).

### Third:
Somehow, though hardcoded, you're not being stated as the Creator of the Osmium logo cape. Here, have a screenshot:
![Screenshot_20210921_202121](https://user-images.githubusercontent.com/85403855/134226126-4c826d04-4c97-416d-84c7-7e76e2fd292f.png)

Otherwise, keep up your great work! Some day, even the big Clients will have to port to Fabric so your mod will already be there against them!