### PR TITLE
The "cosmetics" folder should be *in* the .minecraft (or any other Game Directory) folder, not above it.

### DIFF
--- a/src/main/java/com/intro/client/render/cape/CosmeticManager.java
+++ b/src/main/java/com/intro/client/render/cape/CosmeticManager.java
@@ -102,7 +102,7 @@ public class CosmeticManager {
         putCape(new Cape(genCapeAnimation(new ResourceLocation("osmium", "textures/cape/osmium_logo_cape.png"), "osmium_logo_cape", 1), false, true, "local", "osmium_logo_cape", "Intro"));
 
         try {
-            File cosmeticsDir = FabricLoader.getInstance().getGameDir().getParent().resolve("cosmetics").toFile();
+            File cosmeticsDir = FabricLoader.getInstance().getGameDir().resolve("cosmetics").toFile();
             if(!Files.exists(cosmeticsDir.toPath())) {
                 Files.createDirectory(cosmeticsDir.toPath());
             }


### PR DESCRIPTION
As far as I know, the GameDirectory directly points to the folder we want here, so no need for getParent(). Just close this if it is an unwanted behaviour.